### PR TITLE
채팅 생성 기능 리펙토링

### DIFF
--- a/src/main/java/com/dcm/chat/domain/Chat.java
+++ b/src/main/java/com/dcm/chat/domain/Chat.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 @Table(name = "CHAT")
 public class Chat extends BaseEntity {
 

--- a/src/main/java/com/dcm/chat/domain/ChatMessage.java
+++ b/src/main/java/com/dcm/chat/domain/ChatMessage.java
@@ -14,8 +14,7 @@ public class ChatMessage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long messageId;
 
-    @Column(nullable = false)
-    private Long groupId;
+    private long groupId;
 
     @Column(nullable = false)
     private String email;

--- a/src/main/java/com/dcm/chat/domain/ChatMessage.java
+++ b/src/main/java/com/dcm/chat/domain/ChatMessage.java
@@ -22,7 +22,7 @@ public class ChatMessage extends BaseEntity {
     @Column(nullable = false, length = 200)
     private String message;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatId")
     private Chat chat;
 

--- a/src/main/java/com/dcm/party/controller/PartyController.java
+++ b/src/main/java/com/dcm/party/controller/PartyController.java
@@ -19,8 +19,8 @@ public class PartyController {
     private final PartyService partyService;
 
     @PostMapping
-    public ResponseEntity<Void> writeParty(@RequestBody @Valid PartyRequest request) {
-        partyService.writeParty(request);
+    public ResponseEntity<Void> createParty(@RequestBody @Valid PartyRequest request) {
+        partyService.createParty(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/com/dcm/party/service/PartyService.java
+++ b/src/main/java/com/dcm/party/service/PartyService.java
@@ -24,15 +24,15 @@ public class PartyService {
     private final ChatRepository chatRepository;
 
     @Transactional
-    public void writeParty(PartyRequest request) {
+    public void createParty(PartyRequest request) {
         Hobby hobby = readHobby(request.hobbyId());
         Party party = Party.toEntity(request, hobby);
 
         partyRepository.save(party);
-        writeChat(party);
+        createChat(party);
     }
 
-    private void writeChat(Party party) {
+    private void createChat(Party party) {
         Chat chat = new Chat(party);
         chatRepository.save(chat);
     }

--- a/src/main/java/com/dcm/party/service/PartyService.java
+++ b/src/main/java/com/dcm/party/service/PartyService.java
@@ -38,10 +38,8 @@ public class PartyService {
     }
 
     private Hobby readHobby(Long hobbyId) {
-        Optional<Hobby> hobby = hobbyRepository.findById(hobbyId);
-        if (hobby.isPresent())
-            return hobby.get();
-        throw new NotFoundHobbyException(hobbyId);
+        return hobbyRepository.findById(hobbyId)
+                .orElseThrow(() -> new NotFoundHobbyException(hobbyId));
     }
 
 }

--- a/src/test/java/com/dcm/party/service/PartyServiceTest.java
+++ b/src/test/java/com/dcm/party/service/PartyServiceTest.java
@@ -52,7 +52,7 @@ class PartyServiceTest extends ServiceTest {
         doReturn(hobby).when(hobbyRepository).findById(any(Long.class));
         doReturn(party).when(partyRepository).save(any(Party.class));
         doReturn(chat).when(chatRepository).save(any(Chat.class));
-        partyService.writeParty(partyRequest);
+        partyService.createParty(partyRequest);
 
         // then
         verify(hobbyRepository).findById(1L);


### PR DESCRIPTION
### 작업내용
1. optional 코드 Inline으로 간략하게 코드 간결화.
2. method naming rule 수정 write -> crete, 생성이라는 의미는 create가 더 적절
3. entity 연관 관계 객체에 대한 설정에서 로딩 전략은 Lazy로 설정
4. Long Type의 Field에서 Column nullable false 설정보다는 애초에 null을 허용하지 않는 primitive type으로 수정
5. 중복된 Getter 제거